### PR TITLE
If Demo Undefined, Dont Show Link

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -36,7 +36,7 @@ Report problem or change</a></div> -->
             <script src={{asset "js/jquery-1.11.0.min.js"}}></script>
             <script>
                 var demo=$('.themedemo').attr('src');
-                if (demo != "") {
+                if (demo != undefined) {
                     $('.post-content h3').append(" - <a class='demoLink' target='_blank' href='"+demo+"'>Demo</a>");
                 }
 


### PR DESCRIPTION
Closes #5 
- Changed to if there is no themedemo class, then dont show the demo
